### PR TITLE
In case the col groups is not specified just return black

### DIFF
--- a/d3_clustergram.js
+++ b/d3_clustergram.js
@@ -319,7 +319,9 @@ function Dendrogram(type, params, elem) {
       })
       .style('fill', function(d) {
         var inst_level = params.group_level.col;
-        return get_group_color(d.group[inst_level]);
+	  if (Utils.has(d, 'group'))
+              return get_group_color(d.group[inst_level]);
+	  else return '#000000';
       });
   }
 

--- a/d3_clustergram.js
+++ b/d3_clustergram.js
@@ -300,7 +300,10 @@ function Dendrogram(type, params, elem) {
       .attr('height', params.matrix.y_scale.rangeBand())
       .style('fill', function(d) {
         var inst_level = params.group_level.row;
-        return get_group_color(d.group[inst_level]);
+        if (Utils.has(d, 'group'))
+            return get_group_color(d.group[inst_level]);
+        else
+            return '#000000';
       })
       .attr('x', function() {
         var inst_offset = params.class_room.symbol_width + 1;
@@ -319,9 +322,10 @@ function Dendrogram(type, params, elem) {
       })
       .style('fill', function(d) {
         var inst_level = params.group_level.col;
-	  if (Utils.has(d, 'group'))
-              return get_group_color(d.group[inst_level]);
-	  else return '#000000';
+        if (Utils.has(d, 'group'))
+            return get_group_color(d.group[inst_level]);
+        else
+            return '#000000';
       });
   }
 


### PR DESCRIPTION
Ensures that we can generate viz even is col or row grouping is not provided